### PR TITLE
[WIP] Improve logo positioning on mobile devices

### DIFF
--- a/css/responsive.css
+++ b/css/responsive.css
@@ -527,6 +527,10 @@ responsive CSS
 		line-height: 24px;
 	}
 
+	.tg-slider-widget .slider-content {
+		padding-top: 96px;
+	}
+
 	.tg-slider-widget.slider-content-left .caption-desc,
 	.tg-slider-widget.slider-content-center .caption-desc {
 		font-size: 12px;


### PR DESCRIPTION
For very small screens (max-width: 480px), a top padding for the slider is added to make space for the hamburger menu and logo.

Fixes #47