### PR TITLE
cart disable section in is updated

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -520,7 +520,7 @@ Kirki::add_field(
 		'type'            => 'checkbox',
 		'settings'        => 'flash_header_cart',
 		'label'           => esc_html__( 'Disable', 'flash' ),
-		'section'         => 'flash_header_options',
+		'section'         => 'flash_primary_header',
 		'default'         => '',
 		'priority'        => 50,
 		'active_callback' => 'flash_is_woocommerce_active',

--- a/inc/kirki/README.md
+++ b/inc/kirki/README.md
@@ -1,3 +1,4 @@
+
 # Kirki Customizer Framework #
 **Contributors:** [davidvongries](https://profiles.wordpress.org/davidvongries), [aristath](https://profiles.wordpress.org/aristath), [dannycooper](https://profiles.wordpress.org/dannycooper), [wplemon](https://profiles.wordpress.org/wplemon), [igmoweb](https://profiles.wordpress.org/igmoweb)  
 **Tags:** customizer, options framework, theme, mods, toolkit, gutenberg  
@@ -89,7 +90,7 @@ If you want to integrate Kirki in your theme or plugin, please read the instruct
 
 ### TBD ###
 
-* Fixed: Cart icon disable option.
+* Fix - Option to enable header cart icon not appearing.
 
 ### 3.1.9 - July 19, 2021 ###
 

--- a/inc/kirki/README.md
+++ b/inc/kirki/README.md
@@ -87,6 +87,10 @@ If you want to integrate Kirki in your theme or plugin, please read the instruct
 
 ## Changelog ##
 
+### TBD ###
+
+* Fixed: Cart icon disable option.
+
 ### 3.1.9 - July 19, 2021 ###
 
 * Fixed: Styling issue in Switch control.


### PR DESCRIPTION
What's the issue ?

- The disable cart icon option available in the free version of the Flash theme is not working. The check box is not appearing on the free version of the theme.

What is done in PR?

- Cart disable control section location is updated to flash primary header.

How to test?

- Header > Primary Header >Cart (Diasble Option).
